### PR TITLE
Section 14 Complete, End of Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # FlixelTut
 This dungeon crawler video game is my hand-coded version of a [HaxeFlixel tutorial](http://haxeflixel.com/documentation/tutorial/).
 
-I completed sections 1-12 and documented each function. For the 2-3 files I was asked to copy: I made a note in the commit, read over the copied code, and fixed any typos I found.
+I documented functions, used provided assets, and omitted parts of [section 13](http://haxeflixel.com/documentation/multiple-platforms/)
+since I could not test it on **Windows** or **Android** builds. For the 2-3 files I was asked to copy:
+I made a note in the commit, read over the copied code, and fixed any typos I found.
 
 ## Build Steps
+
+Below are two methods for building the full **Flash** version of the game.
 
 ### Method 1: Using the HaxeDevelop IDE
 

--- a/source/CombatHUD.hx
+++ b/source/CombatHUD.hx
@@ -443,7 +443,7 @@ class CombatHUD extends FlxTypedGroup<FlxSprite>
 			// if we hit, flash the screen white, and deal one damage to the player - then
 			//   update the player's health
 			FlxG.camera.flash(FlxColor.WHITE, .2);
-			FlxG.camera.shake(0.01, 0.2);
+			FlxG.camera.shake(.01, .2);
 			_sndHurt.play();
 			_damages[0].text = "1";
 			playerHealth--;

--- a/source/MenuState.hx
+++ b/source/MenuState.hx
@@ -6,6 +6,7 @@ import flixel.FlxState;
 import flixel.text.FlxText;
 import flixel.ui.FlxButton;
 import flixel.math.FlxMath;
+import flixel.util.FlxColor;
 
 class MenuState extends FlxState
 {
@@ -35,6 +36,9 @@ class MenuState extends FlxState
 		_btnOptions.onUp.sound = FlxG.sound.load(AssetPaths.select__wav);
 		add(_btnOptions);
 
+		// Fade into this state.
+		FlxG.camera.fade(FlxColor.BLACK, .33, true);
+
 		super.create();
 	}
 
@@ -45,11 +49,19 @@ class MenuState extends FlxState
 
 	private function clickPlay():Void
 	{
-		FlxG.switchState(new PlayState());
+		// Fade out of this state.
+		FlxG.camera.fade(FlxColor.BLACK, .33, false, function()
+		{
+			FlxG.switchState(new PlayState());
+		});
 	}
 
 	private function clickOptions():Void
 	{
-		FlxG.switchState(new OptionsState());
+		// Fade out of this state.
+		FlxG.camera.fade(FlxColor.BLACK, .33, false, function()
+		{
+			FlxG.switchState(new OptionsState());
+		});
 	}
 }

--- a/source/OptionsState.hx
+++ b/source/OptionsState.hx
@@ -15,6 +15,11 @@ import flixel.util.FlxSave;
  */
 class OptionsState extends FlxState
 {
+	#if desktop
+	// Button to toggle fullscreen mode on Windows.
+	private var _btnFullScreen:FlxButton;
+	#end
+
 	// define our screen elements
 	private var _txtTitle:FlxText;
 	private var _barVolume:FlxBar;
@@ -24,9 +29,6 @@ class OptionsState extends FlxState
 	private var _btnVolumeUp:FlxButton;
 	private var _btnClearData:FlxButton;
 	private var _btnBack:FlxButton;
-	#if desktop
-	private var _btnFullScreen:FlxButton;
-	#end
 	
 	// a save object for saving settings
 	private var _save:FlxSave;

--- a/source/OptionsState.hx
+++ b/source/OptionsState.hx
@@ -92,6 +92,7 @@ class OptionsState extends FlxState
 		// update our bar to show the current volume level
 		updateVolume();
 		
+		// Fade into this state.
 		FlxG.camera.fade(FlxColor.BLACK, .33, true);
 		
 		super.create();
@@ -124,6 +125,7 @@ class OptionsState extends FlxState
 	private function clickBack():Void
 	{
 		_save.close();
+		// Fade out of this state.
 		FlxG.camera.fade(FlxColor.BLACK, .33, false, function()
 		{
 			FlxG.switchState(new MenuState());

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -69,6 +69,9 @@ class PlayState extends FlxState
 		// Load coin sound.
 		_sndCoin = FlxG.sound.load(AssetPaths.coin__wav);
 
+		// Fade into this state.
+		FlxG.camera.fade(FlxColor.BLACK, .33, true);
+
 		super.create();
 	}
 
@@ -197,7 +200,11 @@ class PlayState extends FlxState
 
 	private function doneFadeOut():Void
 	{
-		// Switches to the Game Over state.
-		FlxG.switchState(new GameOverState(_won, _money));
+		// Fade out of this state.
+		FlxG.camera.fade(FlxColor.BLACK, .33, false, function()
+		{
+			// Switches to the Game Over state.
+			FlxG.switchState(new GameOverState(_won, _money));
+		});
 	}
 }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -69,6 +69,10 @@ class PlayState extends FlxState
 		// Load coin sound.
 		_sndCoin = FlxG.sound.load(AssetPaths.coin__wav);
 
+		#if !FLX_NO_MOUSE
+		FlxG.mouse.visible = false;
+		#end
+
 		// Fade into this state.
 		FlxG.camera.fade(FlxColor.BLACK, .33, true);
 


### PR DESCRIPTION
This PR updates the readme and completes the tutorial by mostly skipping _section 13_ and finishing _section 14_.

## Skip Platform-Specific Features

I mostly skipped _section 13_ because I do not have a way to test its code now. It would require building the game separately for **Windows** and **Android** platforms. I left some existing **Windows** code from section 13 since it does not bother other builds.

## Desired Features

The game works fully on a **Flash** build, and works without fading in/out on an **HTML5** build. Desired future features may include:

* Fixing **HTML5** fade in/out, or disabling fades so transitions are immediate.
* Completing section 13 for **Windows** and **Android** devices.
* Removing the HaxeFlixel introduction, or stopping the music until the HaxeFlixel introduction is over.